### PR TITLE
Pinnate top level list

### DIFF
--- a/lib/ayeaye/pinnate.py
+++ b/lib/ayeaye/pinnate.py
@@ -1,5 +1,6 @@
 import json
 
+
 class Pinnate:
     """
     Dictionary or attribute access to variables loaded either from a JSON
@@ -23,40 +24,109 @@ class Pinnate:
     >>> a.my_things[2].three
     3
     """
+
     def __init__(self, data=None):
         """
-        :param data: dictionary or dictionary encoded in json or instance of Pinnate
+        :param data: mixed
+            can be dictionary or list or set or dictionary/list encoded in json or instance of Pinnate
         """
-        self._attr = {}
+        # this is the 'payload', it's type is decided on first use. It's typically a dictionary because
+        # the attribute nature of Pinnate is the most useful feature. It can also be a list or set.
+        self._attr = None
+
         if isinstance(data, self.__class__):
             self._attr = data._attr
         elif data:
-            self.load(data, merge=False)
+            self.load(data)
+
+    @property
+    def payload_undefined(self):
+        """
+        No data has been set
+
+        @return: boolean
+            No data has been provided so _attrib's type hasn't yet been determined
+        """
+        return self._attr is None
+
+    def is_payload(self, *payload_type):
+        """
+        :class:`Pinnate` can hold mixed data types. Inspect current payload type.
+
+        e.g.
+        >>> p = Pinnate({1:2})
+        >>> p.is_payload(dict)
+        True
+
+        @param *payload_type: type
+            e.g. dict, set or list
+            when multiple payload types are given just one has to match
+
+        @return: boolean
+        """
+        return any([type(self._attr) == pt for pt in payload_type])
 
     def __unicode__(self):
-        d = ', '.join([u"{}:{}".format(k, v) for k, v in self._attr.items()])
-        return '<Pinnate %s>' % d
+        as_str = str(self._attr)
+        return f"<Pinnate {as_str}>"
 
     def __str__(self):
         return self.__unicode__().encode("ascii", "replace").decode()
 
     def keys(self):
+        if self.payload_undefined or not self.is_payload(dict):
+            raise TypeError("Payload data isn't a dictionary")
+
         return self._attr.keys()
 
     def values(self):
-        return self._attr.values()
+        if self.payload_undefined:
+            raise TypeError("Payload data hasn't been set")
+
+        if self.is_payload(dict):
+            return self._attr.values()
+
+        if self.is_payload(list, set):
+            return self._attr
+
+        raise TypeError("Unknown payload data type")
 
     def items(self):
+        if self.payload_undefined or not self.is_payload(dict):
+            raise TypeError("Payload data isn't a dictionary")
+
         return self._attr.items()
 
     def __contains__(self, key):
-        return key in self._attr
+        if self.payload_undefined:
+            raise TypeError("Payload data hasn't been set")
+
+        if self.is_payload(dict, set):
+            return key in self._attr
+
+        raise TypeError("Operation not possible with current payload data type")
+
+    def __iter__(self):
+        """
+        return a generator
+
+        For lists and sets the generator yields each item. For dictionaries it yield (key, value)
+        """
+        if self.is_payload(set, list):
+            return iter(self._attr)
+
+        if self.is_payload(dict):
+            as_key_pairs = [(k, v) for k, v in self._attr.items()]
+            return iter(as_key_pairs)
 
     def as_dict(self, select_fields=None):
         """
         @param select_fields: (list of str) to only include some fields from model.
         @return: (dict) with mixed values
         """
+        if not self.is_payload(dict):
+            raise TypeError(f"as_dict() can only be called when the payload data is a dictionary")
+
         if select_fields is not None:
             r = {}
             for k in select_fields:
@@ -67,19 +137,51 @@ class Pinnate:
                 r[k] = v
             return r
         else:
-            return {k: v.as_dict() if isinstance(v, self.__class__) else v \
-                    for k, v in self._attr.items()}
+            return {
+                k: v.as_native() if isinstance(v, self.__class__) else v
+                for k, v in self._attr.items()
+            }
+
+    def as_native(self):
+        """
+        @return: (mixed)
+            representation of the payload (as children elements) comprised of
+            native python data types.
+        """
+        if self.payload_undefined:
+            return None
+
+        if self.is_payload(dict):
+            return self.as_dict()
+
+        if self.is_payload(list):
+            r = []
+            for item in self._attr:
+                value = item.as_native() if isinstance(item, self.__class__) else item
+                r.append(value)
+            return r
+
+        if self.is_payload(set):
+            r = set()
+            for item in self._attr:
+                value = item.as_native() if isinstance(item, self.__class__) else item
+                r.add(value)
+            return r
+
+        raise TypeError("Unsupported type")
 
     def as_json(self, *args, **kwargs):
         """
         @see :method:`as_dict` for params.
         @returns (str) JSON representation
         """
-        return json.dumps(self.as_dict(*args, **kwargs), default=str)
+        return json.dumps(self.as_native(*args, **kwargs), default=str)
 
     def __getattr__(self, attr):
         if attr not in self._attr:
-            raise AttributeError("{} instance has no attribute '{}'".format(self.__class__.__name__, attr))
+            raise AttributeError(
+                "{} instance has no attribute '{}'".format(self.__class__.__name__, attr)
+            )
         if isinstance(self._attr[attr], list):
 
             def list_recurse(item):
@@ -102,7 +204,10 @@ class Pinnate:
 
     def __setattr__(self, attr, val):
         super(Pinnate, self).__setattr__(attr, val)
-        if attr != '_attr':
+        if attr != "_attr":
+            if self.payload_undefined:
+                self._attr = {}
+
             self._attr[attr] = val
 
     def __getitem__(self, key):
@@ -114,57 +219,83 @@ class Pinnate:
     def get(self, key, default=None):
         return self._attr.get(key, default)
 
-    def load(self, data, merge=False):
+    def load(self, data):
         """
-        :param data: dict or json string
+        :param data: dict, list, set or json string
         :param merge: bool see :method:`update` if False or :method:`merge` when True.
         """
 
-        if not isinstance(data, dict):
+        if isinstance(data, str):
             data = json.loads(data)
 
-        if merge:
-            self.merge(data)
-        else:
-            self.update(data)
+        self.update(data)
 
     def update(self, data):
         """
-        Extend the Pinnate with further settings. If a setting with an existing key is supplied,
-        then the previous value is overwritten.
+        Extend the Pinnate with further payload values.
 
-        :param data: dictionary or dictionary encoded in json
+        If a setting with an existing key is supplied, then the previous value is overwritten.
+
+        If the payload is a -
+         - list - it will be extended
+         - set - added to
+         - dict - merged
+
+        :param data: dictionary or list or set or json string
         """
-        for k, v in data.items():
-            if isinstance(v, dict):
-                self._attr[k] = Pinnate(v)
-            else:
-                self._attr[k] = v
 
-    def merge(self, data):
-        """
-        Extend the Pinnate with further settings. If a setting with an existing key is supplied,
-        then the previous value is either updated (if the previous value is a dict) or overwritten
-        (if the previous value is a scalar).
+        if not isinstance(data, (dict, list, set)):
+            raise TypeError("Unsupported type")
 
-        Where corresponding values are not of compatible types, a ValueError is raised. Compatible
-        means that an existing dict value must remain a dict (thus the dicts are merged), or a
-        non-dict value must remain a non-dict type.
+        if self.payload_undefined:
 
-        :param data: dictionary or dictionary encoded in json
-        """
-        for k, v in data.items():
-            if isinstance(v, dict):
-                try:
-                    self._attr[k].merge(v)
-                except KeyError:
+            if isinstance(data, dict):
+                self._attr = {}
+            elif isinstance(data, set):
+                self._attr = set()
+            elif isinstance(data, list):
+                self._attr = []
+
+        if not self.is_payload(type(data)):
+            p_type = str(type(self._attr))
+            d_type = str(type(data))
+            msg = (
+                f"The type of the update data '{d_type}' doesn't match current payload's "
+                f"type: '{p_type}'"
+            )
+            raise TypeError(msg)
+
+        if self.is_payload(dict):
+            for k, v in data.items():
+                if isinstance(v, dict):
                     self._attr[k] = Pinnate(v)
-                except AttributeError:
-                    raise ValueError("Invalid key '{}'".format(k))
-            else:
-                if k in self._attr and isinstance(self._attr[k], self.__class__):
-                    msg = ("Key '{}' attempted to overwrite an existing Pinnate."
-                            "Operation not permitted."
-                            )
-                    raise ValueError(msg.format(k))
-                self._attr[k] = v
+                else:
+                    self._attr[k] = v
+
+        elif self.is_payload(list):
+
+            for v in data:
+                if isinstance(v, dict):
+                    self._attr.append(Pinnate(v))
+                else:
+                    self._attr.append(v)
+
+        elif self.is_payload(set):
+
+            for v in data:
+                if isinstance(v, dict):
+                    self._attr.add(Pinnate(v))
+                else:
+                    self._attr.add(v)
+
+    def append(self, item):
+        """
+        Can be used to add item when the payload is a list.
+        """
+        self.update([item])
+
+    def add(self, item):
+        """
+        Can be used to add item when the payload is a list.
+        """
+        self.update(set([item]))

--- a/tests/test_pinnate.py
+++ b/tests/test_pinnate.py
@@ -6,13 +6,13 @@ from ayeaye.pinnate import Pinnate
 
 class TestPinnate(unittest.TestCase):
     def test_attrib_and_dict(self):
-        a = Pinnate({'my_string': 'abcdef'})
-        self.assertEqual(a.my_string, 'abcdef')
-        self.assertEqual(a['my_string'], 'abcdef')
-        self.assertEqual(a.as_dict(), {'my_string': 'abcdef'})
+        a = Pinnate({"my_string": "abcdef"})
+        self.assertEqual(a.my_string, "abcdef")
+        self.assertEqual(a["my_string"], "abcdef")
+        self.assertEqual(a.as_dict(), {"my_string": "abcdef"})
 
     def test_recurse(self):
-        d = {'my_things': [1, 2, {'three': 3}]}
+        d = {"my_things": [1, 2, {"three": 3}]}
         a = Pinnate(d)
         p = a.my_things
         self.assertTrue(p[0] == 1 and p[1] == 2 and isinstance(p[2], Pinnate))
@@ -22,43 +22,128 @@ class TestPinnate(unittest.TestCase):
         """
         check it's possible to give a variable the same name as an existing method.
         """
-        d = {'as_dict': 1}
+        d = {"as_dict": 1}
         p = Pinnate(d)
         self.assertEqual("{'as_dict': 1}", str(p.as_dict()))
 
     def test_as_json(self):
-        d = {'number': 1,
-             'string': 'hello',
-             'date': datetime.strptime("2020-01-15 10:34:12", "%Y-%m-%d %H:%M:%S"),
-             'recurse_list': [{'abc': 'def'}],
-             'recurse_dict': {'ghi': {'jkl': 'mno'}
-                              },
-             }
+        d = {
+            "number": 1,
+            "string": "hello",
+            "date": datetime.strptime("2020-01-15 10:34:12", "%Y-%m-%d %H:%M:%S"),
+            "recurse_list": [{"abc": "def"}],
+            "recurse_dict": {"ghi": {"jkl": "mno"}},
+        }
         p = Pinnate(d)
         as_json = str(p.as_json())
-        expected = ('{"number": 1, "string": "hello", "date": "2020-01-15 10:34:12", '
-                    '"recurse_list": [{"abc": "def"}], "recurse_dict": {"ghi": {"jkl": "mno"}}}'
-                    )
+        expected = (
+            '{"number": 1, "string": "hello", "date": "2020-01-15 10:34:12", '
+            '"recurse_list": [{"abc": "def"}], "recurse_dict": {"ghi": {"jkl": "mno"}}}'
+        )
         self.assertEqual(expected, as_json)
 
     def test_recursive_lists(self):
         "bug found with list inside a list"
 
-        d = {'name': 'Stall Street',
-             'type': 'Line',
-             'payload': [[-2.3597675, 51.3797509], [-2.359739, 51.3797783]],
-             'tags': {'name': 'Stall Street',
-                      'oneway': 'yes',
-                      'highway': 'unclassified',
-                      'motor_vehicle:conditional': 'no @ (10:00-18:00)'
-                      }
-             }
+        d = {
+            "name": "Stall Street",
+            "type": "Line",
+            "payload": [[-2.3597675, 51.3797509], [-2.359739, 51.3797783]],
+            "tags": {
+                "name": "Stall Street",
+                "oneway": "yes",
+                "highway": "unclassified",
+                "motor_vehicle:conditional": "no @ (10:00-18:00)",
+            },
+        }
         p = Pinnate(d)
         # accessing the item triggered the bug
         self.assertEqual(-2.3597675, p.payload[0][0])
 
-
         # deeper recurse
-        d = {'a': [[[{'b':'hello'}]]]}
+        d = {"a": [[[{"b": "hello"}]]]}
         p = Pinnate(d)
-        self.assertEqual('hello', p.a[0][0][0].b)
+        self.assertEqual("hello", p.a[0][0][0].b)
+
+    def test_top_level_list(self):
+        "test you can make a Pinnate from a top level list"
+
+        l = ["a", "b", "c"]
+
+        p = Pinnate(l)
+
+        self.assertEqual(p[0], "a")
+        self.assertEqual(p[1], "b")
+        self.assertEqual(p[2], "c")
+
+    def test_top_level_list_of_dict(self):
+        "test you can make a Pinnate from a top level list of dictionaries"
+
+        l = [{"first_name": "mary"}, {"last_name": "poppins"}]
+
+        p = Pinnate(l)
+
+        self.assertEqual(p[0].first_name, "mary")
+        self.assertEqual(p[1].last_name, "poppins")
+
+    def test_update_dict(self):
+        "test you can update an existing dict into a Pinnate made from a dict"
+
+        first_name = {"first_name": "mary"}
+        p = Pinnate(first_name)
+
+        last_name = {"last_name": "poppins"}
+        p.update(last_name)
+
+        self.assertEqual(p.first_name, "mary")
+        self.assertEqual(p.last_name, "poppins")
+
+    def test_update_list(self):
+        "test you can update a list into a Pinnate made from a list"
+
+        l_one = [1, 2]
+        p = Pinnate(l_one)
+
+        l_two = [2, 3]
+        p.update(l_two)
+
+        self.assertEqual(p[0], 1)
+        self.assertEqual(p[1], 2)
+        self.assertEqual(p[2], 2)
+        self.assertEqual(p[3], 3)
+
+    def test_top_level_iterator(self):
+        "a list at the top level makes the Pinnate behave like a normal list"
+
+        p = Pinnate(["a", "b", "c"])
+        joined_values = "".join(p)
+
+        self.assertEqual("abc", joined_values)
+        self.assertFalse(isinstance(p, list), "It's a Pinnate, not a list")
+
+        # same behaviour at 2nd level
+        px = Pinnate({"xx": ["a", "b", "c"]})
+        joined_values = "".join(px.xx)
+        self.assertEqual("abc", joined_values)
+        self.assertIsInstance(px.xx, list, "Second level really is a list")
+
+    def test_late_construction(self):
+        "Pinnate becomes a list or dict or set but not during construction"
+        # list
+        p = Pinnate()
+        p.append("x")
+        self.assertEqual("x", p[0])
+
+        # set
+        p = Pinnate()
+        p.add("x")
+        self.assertIn("x", p)
+
+        # dict
+        p = Pinnate()
+        p.x = "y"
+        self.assertEqual(p["x"], "y")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* added: unit tests to test that you can make a Pinnate from a top level list, and a top level list of dictionaries. they error currently

* added: black formatting
added: a unittest for expected behaviour

* updated: Pinnate to support lists, sets and dict at top level
removed: Pinnate.merge - I don't think this does anything different to .update

Co-authored-by: Si Parker <si@plogic.co.uk>