### PR TITLE
Change build to be called before subtasks

### DIFF
--- a/lib/ayeaye/model.py
+++ b/lib/ayeaye/model.py
@@ -449,8 +449,7 @@ class PartitionedModel(Model):
 
         self.build()
 
-        tasks = []
-        tasks.extend(self.partition_slice(workers_count))
+        tasks = self.partition_slice(workers_count)
         subtasks_count = len(tasks)
 
         # model can specify arguments for initialising workers

--- a/lib/ayeaye/model.py
+++ b/lib/ayeaye/model.py
@@ -447,7 +447,9 @@ class PartitionedModel(Model):
         # workers_count =  1
         self.log(f"Using {workers_count} worker processes")
 
-        tasks = [("build", None)]  # all subclasses of :class:`Model` must include `build` method
+        self.build()
+
+        tasks = []
         tasks.extend(self.partition_slice(workers_count))
         subtasks_count = len(tasks)
 


### PR DESCRIPTION
The `build` method in `PartitionedModel` is called by the same mechanism as the other subtasks. This means that it is not guaranteed to be called before a subtask so there is no obvious place for pre subtask work.

This PR moves the execution of `build` so that it is executed called by the main process before subtask are executed.

This will mean that `build` is now a blocking activity.
