### PR TITLE
Set delimiter of csv connector

### DIFF
--- a/lib/ayeaye/connectors/base.py
+++ b/lib/ayeaye/connectors/base.py
@@ -417,6 +417,8 @@ class FileBasedConnector(DataConnector):
     This is a mixin for common functionality between file based `DataConnector` modules.
     """
 
+    optional_args = {"encoding": None}
+
     # class variables that can be defined by subclasses or left as are or overwritten with instance
     # variable.
     optional_engine_url_args = ["encoding"]  # list of str
@@ -559,6 +561,13 @@ class FileBasedConnector(DataConnector):
             self._encoding = ep.encoding if "encoding" in ep else self.default_character_encoding
 
         return self._encoding
+
+    @encoding.setter
+    def encoding(self, encoding):
+        """
+        Cater for encoding being settable via engine params as well as via optional args.
+        """
+        self._encoding = encoding
 
     def close_connection(self):
         super().close_connection()

--- a/lib/ayeaye/connectors/base.py
+++ b/lib/ayeaye/connectors/base.py
@@ -427,9 +427,6 @@ class FileBasedConnector(DataConnector):
     file_mode = "t"
     engine_pattern_expander_cls = FilesystemEnginePattern
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _reset(self):
         """
         Subclasses must call this within the constructor
@@ -564,7 +561,8 @@ class FileBasedConnector(DataConnector):
     @encoding.setter
     def encoding(self, encoding):
         """
-        Cater for encoding being settable via engine params as well as via optional args.
+        This is used when encoding is set via engine optional args to cater for encoding also being
+        settable via engine params.
         """
         self._encoding = encoding
 

--- a/lib/ayeaye/connectors/base.py
+++ b/lib/ayeaye/connectors/base.py
@@ -422,18 +422,19 @@ class FileBasedConnector(DataConnector):
     # class variables that can be defined by subclasses or left as are or overwritten with instance
     # variable.
     optional_engine_url_args = ["encoding"]  # list of str
-    default_character_encoding = None
     write_mode_open_args = {}
     # default is for files to be opened in text mode
     file_mode = "t"
     engine_pattern_expander_cls = FilesystemEnginePattern
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def _reset(self):
         """
         Subclasses must call this within the constructor
         """
         self._file_handle = None
-        self._encoding = None
         self._engine_params = None
         self.file_size = None
 
@@ -455,11 +456,9 @@ class FileBasedConnector(DataConnector):
         """
 
         ep = self.ignition._decode_filesystem_engine_url(
-            self.engine_url, optional_args=self.optional_engine_url_args
+            self.engine_url,
+            optional_args=self.optional_engine_url_args,
         )
-
-        if "encoding" in ep:
-            self._encoding = ep.encoding
 
         return ep
 
@@ -556,9 +555,9 @@ class FileBasedConnector(DataConnector):
         """
         default encoding. 'sig' means don't include the unicode BOM
         """
-        if self._encoding is None:
-            ep = self.engine_params
-            self._encoding = ep.encoding if "encoding" in ep else self.default_character_encoding
+        # engine_url's 'encoding' param is optional, it takes precedence when set
+        if "encoding" in self.engine_params:
+            return self.engine_params.encoding
 
         return self._encoding
 

--- a/lib/ayeaye/connectors/csv_connector.py
+++ b/lib/ayeaye/connectors/csv_connector.py
@@ -20,6 +20,8 @@ class CsvConnector(FileBasedConnector):
         "alias_fields": None,
         "quoting": None,
         "transform_map": {},
+        "encoding": None,
+        "delimiter": ",",
     }
     optional_engine_url_args = FileBasedConnector.optional_engine_url_args + ["start", "end"]
     default_character_encoding = "utf-8-sig"
@@ -62,6 +64,11 @@ class CsvConnector(FileBasedConnector):
                     written or the value yielded from the connector. See unittest
                     TestConnectorsCsv.test_transforms for and example of how to use this.
 
+            encoding (str) see superclass
+
+            delimiter (str)
+                    Used to separate fields.
+
         Connection information-
             engine_url format is
             csv://<filesystem absolute path>data_file.csv[;start=<line number>][;end=<line number>][;encoding=<character encoding>]
@@ -74,7 +81,6 @@ class CsvConnector(FileBasedConnector):
         # schemas are implemented. For now, keep track so loading fieldnames from file doesn't
         # make a :meth:`_reset`
         self.base_field_names = copy.copy(self.field_names)
-        self.delimiter = ","
 
         if self.access == AccessMode.READWRITE:
             raise NotImplementedError("Read+Write access not yet implemented")

--- a/lib/ayeaye/connectors/csv_connector.py
+++ b/lib/ayeaye/connectors/csv_connector.py
@@ -14,17 +14,17 @@ from ayeaye.pinnate import Pinnate
 class CsvConnector(FileBasedConnector):
     engine_type = "csv://"
     optional_args = {
+        **FileBasedConnector.optional_args,
         "field_names": None,
         "required_fields": None,
         "expected_fields": None,
         "alias_fields": None,
         "quoting": None,
         "transform_map": {},
-        "encoding": None,
+        "encoding": "utf-8-sig",
         "delimiter": ",",
     }
     optional_engine_url_args = FileBasedConnector.optional_engine_url_args + ["start", "end"]
-    default_character_encoding = "utf-8-sig"
     write_mode_open_args = {"newline": "\n"}
 
     def __init__(self, *args, **kwargs):

--- a/lib/ayeaye/connectors/json_connector.py
+++ b/lib/ayeaye/connectors/json_connector.py
@@ -15,6 +15,7 @@ class JsonConnector(FileBasedConnector):
     engine_type = "json://"
     optional_engine_url_args = FileBasedConnector.optional_engine_url_args + ["indent"]
     default_character_encoding = "utf-8-sig"
+    optional_args = {"encoding": None}
 
     def __init__(self, *args, **kwargs):
         """

--- a/lib/ayeaye/connectors/json_connector.py
+++ b/lib/ayeaye/connectors/json_connector.py
@@ -14,8 +14,10 @@ from ayeaye.pinnate import Pinnate
 class JsonConnector(FileBasedConnector):
     engine_type = "json://"
     optional_engine_url_args = FileBasedConnector.optional_engine_url_args + ["indent"]
-    default_character_encoding = "utf-8-sig"
-    optional_args = {"encoding": None}
+    optional_args = {
+        **FileBasedConnector.optional_args,
+        "encoding": "utf-8-sig",
+    }
 
     def __init__(self, *args, **kwargs):
         """

--- a/lib/ayeaye/connectors/ndjson_connector.py
+++ b/lib/ayeaye/connectors/ndjson_connector.py
@@ -3,6 +3,7 @@ Created on 17 Dec 2020
 
 @author: si
 """
+
 try:
     import ndjson
 except ModuleNotFoundError:
@@ -15,6 +16,7 @@ from ayeaye.pinnate import Pinnate
 class NdjsonConnector(FileBasedConnector):
     engine_type = "ndjson://"
     default_character_encoding = "utf-8-sig"
+    optional_args = {"encoding": None}
 
     def __init__(self, *args, **kwargs):
         """

--- a/lib/ayeaye/connectors/ndjson_connector.py
+++ b/lib/ayeaye/connectors/ndjson_connector.py
@@ -15,8 +15,10 @@ from ayeaye.pinnate import Pinnate
 
 class NdjsonConnector(FileBasedConnector):
     engine_type = "ndjson://"
-    default_character_encoding = "utf-8-sig"
-    optional_args = {"encoding": None}
+    optional_args = {
+        **FileBasedConnector.optional_args,
+        "encoding": "utf-8-sig",
+    }
 
     def __init__(self, *args, **kwargs):
         """

--- a/lib/ayeaye/connectors/uncooked_connector.py
+++ b/lib/ayeaye/connectors/uncooked_connector.py
@@ -9,7 +9,10 @@ from ayeaye.connectors.base import AccessMode, FileBasedConnector
 
 class UncookedConnector(FileBasedConnector):
     engine_type = "file://"
-    optional_args = {"file_mode": "t", "encoding": None}
+    optional_args = {
+        **FileBasedConnector.optional_args,
+        "file_mode": "t",
+    }
 
     def __init__(self, *args, **kwargs):
         """

--- a/lib/ayeaye/connectors/uncooked_connector.py
+++ b/lib/ayeaye/connectors/uncooked_connector.py
@@ -3,14 +3,13 @@ Created on 19 May 2021
 
 @author: si
 """
+
 from ayeaye.connectors.base import AccessMode, FileBasedConnector
 
 
 class UncookedConnector(FileBasedConnector):
     engine_type = "file://"
-    optional_args = {
-        "file_mode": "t",
-    }
+    optional_args = {"file_mode": "t", "encoding": None}
 
     def __init__(self, *args, **kwargs):
         """

--- a/tests/data/pigs_unusual_delimiter.csv
+++ b/tests/data/pigs_unusual_delimiter.csv
@@ -1,0 +1,3 @@
+common_name;native_to
+Wild Boar;Europe, North Africa, and much of Asia
+Visayan Warty Pig;Visayan Islands

--- a/tests/test_connectors/test_connectors_csv.py
+++ b/tests/test_connectors/test_connectors_csv.py
@@ -222,7 +222,6 @@ class TestConnectorsCsv(unittest.TestCase):
     def test_delimiter(self):
         c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_UNUSUAL_DELIMITER, delimiter=";")
         r = next(iter(c))
-        # doesn't raise an exception as fields are exactly as given in file's header
         self.assertEqual(r.common_name, "Wild Boar")
         self.assertEqual(r.native_to, "Europe, North Africa, and much of Asia")
 

--- a/tests/test_connectors/test_connectors_csv.py
+++ b/tests/test_connectors/test_connectors_csv.py
@@ -16,6 +16,7 @@ EXAMPLE_CSV_MICE = os.path.join(TEST_DATA_PATH, "mice_no_heading.csv")
 EXAMPLE_CSV_SQUIRRELS = os.path.join(TEST_DATA_PATH, "squirrels_no_heading.csv")
 EXAMPLE_CSV_DUPLICATE_FIELDNAMES = os.path.join(TEST_DATA_PATH, "duplicate_field_names.csv")
 EXAMPLE_CSV_QUOTED = os.path.join(TEST_DATA_PATH, "venomous_spiders.csv")
+EXAMPLE_CSV_UNUSUAL_DELIMITER = os.path.join(TEST_DATA_PATH, "pigs_unusual_delimiter.csv")
 
 
 class TestConnectorsCsv(unittest.TestCase):
@@ -64,15 +65,23 @@ class TestConnectorsCsv(unittest.TestCase):
         expected = "Goeldi's marmoset, Common squirrel monkey, Crab-eating macaque"
         assert expected == monkey_names
 
-    def test_csv_encoding(self):
+    def test_csv_encoding_default(self):
         """
-        Specify character encoding in the URL. This test doesn't ensure data conforms.
+        Test the default encoding for CsvConnector.
+        This test doesn't ensure data conforms.
         """
         c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH)
         self.assertEqual("utf-8-sig", c.encoding, "Unexpected default encoding")
 
-        c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH + ";encoding=latin-1")
-        self.assertEqual("latin-1", c.encoding, "Can't override default encoding")
+    def test_csv_encoding_settable(self):
+        "specify character encoding in the URL and in engine params."
+        encoding = "latin-1"
+
+        # c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH + ";encoding=" + encoding)
+        # self.assertEqual(encoding, c.encoding)
+
+        c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH, encoding=encoding)
+        self.assertEqual(encoding, c.encoding)
 
     def test_csv_engine_decode(self):
         c = CsvConnector(engine_url="csv:///data/abc.csv")
@@ -209,6 +218,13 @@ class TestConnectorsCsv(unittest.TestCase):
         # missing field
         with self.assertRaises(ValueError):
             next(iter(c))
+
+    def test_delimiter(self):
+        c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_UNUSUAL_DELIMITER, delimiter=";")
+        r = next(iter(c))
+        # doesn't raise an exception as fields are exactly as given in file's header
+        self.assertEqual(r.common_name, "Wild Boar")
+        self.assertEqual(r.native_to, "Europe, North Africa, and much of Asia")
 
     def test_alias_fields_dictionary(self):
         c = CsvConnector(

--- a/tests/test_connectors/test_connectors_csv.py
+++ b/tests/test_connectors/test_connectors_csv.py
@@ -77,8 +77,8 @@ class TestConnectorsCsv(unittest.TestCase):
         "specify character encoding in the URL and in engine params."
         encoding = "latin-1"
 
-        # c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH + ";encoding=" + encoding)
-        # self.assertEqual(encoding, c.encoding)
+        c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH + ";encoding=" + encoding)
+        self.assertEqual(encoding, c.encoding)
 
         c = CsvConnector(engine_url="csv://" + EXAMPLE_CSV_PATH, encoding=encoding)
         self.assertEqual(encoding, c.encoding)


### PR DESCRIPTION
- added encoding to optional args of FileBasedConnector
- kept encoding being able to be passed in via engine params, passing in via engine params takes priority when passed in via both
- added delimiter as an optional arg of CsvConnector