### PR TITLE
connectors to catch more general import error

### DIFF
--- a/lib/ayeaye/connectors/bigquery.py
+++ b/lib/ayeaye/connectors/bigquery.py
@@ -1,7 +1,7 @@
 try:
     from google.cloud import bigquery
     from google.cloud.exceptions import NotFound
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from ayeaye.connectors.base import AccessMode, DataConnector

--- a/lib/ayeaye/connectors/elasticsearch_connector.py
+++ b/lib/ayeaye/connectors/elasticsearch_connector.py
@@ -1,7 +1,7 @@
 try:
     # pipenv install elasticsearch
     from elasticsearch import Elasticsearch
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from ayeaye.connectors.base import DataConnector, AccessMode

--- a/lib/ayeaye/connectors/engine_type_modifiers/smart_open_modifier.py
+++ b/lib/ayeaye/connectors/engine_type_modifiers/smart_open_modifier.py
@@ -5,7 +5,7 @@ import warnings
 try:
     from smart_open import open as smart_open
     import boto3
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from ayeaye.connectors.base import AccessMode, DataFlow, FileBasedConnector, FilesystemEnginePattern

--- a/lib/ayeaye/connectors/kafka_connector.py
+++ b/lib/ayeaye/connectors/kafka_connector.py
@@ -9,7 +9,7 @@ from typing import Generator
 try:
     from kafka import KafkaConsumer, KafkaProducer, TopicPartition
     from kafka.structs import OffsetAndTimestamp
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from ayeaye.connectors.base import DataConnector, AccessMode

--- a/lib/ayeaye/connectors/ndjson_connector.py
+++ b/lib/ayeaye/connectors/ndjson_connector.py
@@ -6,7 +6,7 @@ Created on 17 Dec 2020
 
 try:
     import ndjson
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from ayeaye.connectors.base import AccessMode, FileBasedConnector

--- a/lib/ayeaye/connectors/parquet_connector.py
+++ b/lib/ayeaye/connectors/parquet_connector.py
@@ -10,7 +10,7 @@ Created on 14 Jan 2020
 """
 try:
     import pyarrow.parquet as pq
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 import os

--- a/lib/ayeaye/connectors/restful_connector.py
+++ b/lib/ayeaye/connectors/restful_connector.py
@@ -9,7 +9,7 @@ from time import time
 
 try:
     import requests
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 

--- a/lib/ayeaye/connectors/sqlalchemy_database.py
+++ b/lib/ayeaye/connectors/sqlalchemy_database.py
@@ -9,7 +9,7 @@ try:
     from sqlalchemy.ext.declarative import DeclarativeMeta
     from sqlalchemy.orm import declarative_base, sessionmaker
     from sqlalchemy.sql import text
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from ayeaye.connectors.base import DataConnector, DataFlow, AccessMode

--- a/tests/test_connectors/test_connectors_parquet.py
+++ b/tests/test_connectors/test_connectors_parquet.py
@@ -4,12 +4,12 @@ import unittest
 PANDAS_NOT_INSTALLED = False
 try:
     import pandas as pd
-except ModuleNotFoundError:
+except ImportError:
     pd = None
 
 try:
     import pyarrow.parquet as pq
-except ModuleNotFoundError:
+except ImportError:
     pq = None
 
 


### PR DESCRIPTION
Updated the catch in the connectors so if there is a problem importing a package they catch ImportError instead of the more specific ModuleNotFoundError.